### PR TITLE
Day01 solved.

### DIFF
--- a/day01-1.awk
+++ b/day01-1.awk
@@ -1,0 +1,17 @@
+BEGIN {
+    count=0;
+    maxi=0;
+} 
+{
+    if(NF==0) {
+        if(maxi<count) maxi = count;
+        count = 0;
+    } else {
+        count += $1;
+    }
+}  
+
+END {
+    if(maxi<count) maxi = count;
+    print maxi;
+}

--- a/day01-2.awk
+++ b/day01-2.awk
@@ -1,0 +1,19 @@
+BEGIN {
+    n=0;
+    count=0;
+    maxi=0;
+} 
+{
+    if(NF==0) {
+        arr[++n] = count;
+        count = 0;
+    } else {
+        count += $1;
+    }
+}  
+
+END {
+    arr[++n] =count;
+    n = asort(arr);
+    print arr[n]+arr[n-1]+arr[n-2];
+}


### PR DESCRIPTION
It was a simple problem, and I could quickly solve it using `awk`.

* rows with a empty line & after all rows are where we need to calculate each Elf's calories.
* `asort` could work, and I initially doubted that the function only works for string, but the GNU manual confirmed that it has to work with numeric values:
> After the call to asort(), the array data is indexed from 1 to some number n, the total number of elements in data. (This count is asort()’s return value.) data[1] <= data[2] <= data[3], and so on. The default comparison is based on the type of the elements (see [Variable Typing and Comparison Expressions](https://www.gnu.org/software/gawk/manual/html_node/Typing-and-Comparison.html)). All numeric values come before all string values, which in turn come before all subarrays.